### PR TITLE
Fixed node version issue and sqlite3/py27 issue

### DIFF
--- a/CMD
+++ b/CMD
@@ -1,4 +1,4 @@
-ln -s /usr/local/bin/python2.7 /usr/local/python
+ln -s /usr/local/bin/python2.7 /usr/local/bin/python
 
 npm install -g ghost-cli
 

--- a/CMD
+++ b/CMD
@@ -1,7 +1,7 @@
 
 npm install -g ghost-cli
 
-cd ~/Documents
+cd ~
 mkdir ghost
 cd ghost
 pwd

--- a/CMD
+++ b/CMD
@@ -1,6 +1,5 @@
 ln -s /usr/local/bin/python2.7 /usr/local/python
 
-npm install sqlite3 --save
 npm install -g ghost-cli
 
 cd ~
@@ -13,6 +12,8 @@ mkdir ~/repo
 cd ~/repo
 git clone https://github.com/DrBoyle/bastille-ghost-ipfix.git
 ln -s ~/repo/bastille-ghost-ipfix/fixIP.py ~/ghost/fixIP.py
+
+npm install sqlite3 --save
 
 cd ~/ghost
 cp config.development.json config.production.json

--- a/CMD
+++ b/CMD
@@ -1,4 +1,6 @@
+ln -s /usr/local/bin/python2.7 /usr/local/python
 
+npm install sqlite3 --save
 npm install -g ghost-cli
 
 cd ~
@@ -7,6 +9,15 @@ cd ghost
 pwd
 ghost install local
 
+mkdir ~/repo
+cd ~/repo
+git clone https://github.com/DrBoyle/bastille-ghost-ipfix.git
+ln -s ~/repo/bastille-ghost-ipfix/fixIP.py ~/ghost/fixIP.py
 
+cd ~/ghost
+cp config.development.json config.production.json
+ifconfig bastille0 | awk '$1 == "inet" {print $2 > "jailIP.md"}'
+python fixIP.py
+ghost start
 
 

--- a/CMD
+++ b/CMD
@@ -7,18 +7,3 @@ mkdir ghost
 cd ghost
 pwd
 ghost install local
-
-mkdir ~/repo
-cd ~/repo
-git clone https://github.com/DrBoyle/bastille-ghost-ipfix.git
-ln -s ~/repo/bastille-ghost-ipfix/fixIP.py ~/ghost/fixIP.py
-
-npm install sqlite3 --save
-
-cd ~/ghost
-cp config.development.json config.production.json
-ifconfig bastille0 | awk '$1 == "inet" {print $2 > "jailIP.md"}'
-python fixIP.py
-ghost start
-
-

--- a/PKG
+++ b/PKG
@@ -1,3 +1,3 @@
-node
-npm
+node12
+npm-node12
 

--- a/PKG
+++ b/PKG
@@ -1,3 +1,4 @@
 node12
 npm-node12
+git-lite
 

--- a/PKG
+++ b/PKG
@@ -1,4 +1,2 @@
 node12
 npm-node12
-git-lite
-


### PR DESCRIPTION
Added a symlink from python2.7 -> python so npm can install sqlite3 properly. Changed PKG to use versions of node and npm that are compatible with ghost.